### PR TITLE
Time barrier (no endloess loops when looking up Feb 30th) & optional seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ cron
  
  Since it's specified on Joda-time it allows for easy integration into unit testing and simulations, by adjusting the Joda-time offset to speed up executions.
  
+fork
+====
+
+ This project was forked from https://github.com/frode-carlsen/cron and has the following new features:
+
+ - Seconds can be omitted in the cron expression.
+
+ - No endless loop if a non existing date (february 30th) is specified in the cron expression. This fork uses a date/time barrier. If the search for the next execution date/time reaches this barrier, an InvalidArgumentException is thrown. This barrier can be user-defined, but has a built-in default of 4 years.
+ 
 usage
 =====
  See javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>fc.cron</groupId>
   <artifactId>cron</artifactId>
   <packaging>jar</packaging>
-  <version>1.1</version>
+  <version>1.2</version>
   <name>cron</name>
   <url>https://github.com/frode-carlsen/cron</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>fc.cron</groupId>
   <artifactId>cron</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.1</version>
   <name>cron</name>
   <url>https://github.com/frode-carlsen/cron</url>
   
@@ -14,21 +14,21 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
   </licenses>
-	
+
   <dependencies>
      <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.3</version>
      </dependency>
-	  
-	<dependency>
+  
+     <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert</artifactId>
       <version>1.4</version>
-	  <scope>test</scope>
+      <scope>test</scope>
     </dependency>
-	  
+  
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -39,7 +39,7 @@
   
   <build>
     <plugins>
-	  <plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
@@ -53,7 +53,7 @@
   </build>
   
   <properties>
-	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>fc.cron</groupId>
   <artifactId>cron</artifactId>
   <packaging>jar</packaging>
-  <version>1.2</version>
+  <version>1.3</version>
   <name>cron</name>
   <url>https://github.com/frode-carlsen/cron</url>
   

--- a/src/main/java/fc/cron/CronExpression.java
+++ b/src/main/java/fc/cron/CronExpression.java
@@ -32,7 +32,7 @@ import org.joda.time.MutableDateTime;
  * Parser for unix-like cron expressions: Cron expressions allow specifying combinations of criteria for time
  * such as: &quot;Each Monday-Friday at 08:00&quot; or &quot;Every last friday of the month at 01:30&quot;
  * <p>
- * A cron expressions consists of 6 mandatory fields separated by space. <br>
+ * A cron expressions consists of 5 or 6 mandatory fields (seconds may be omitted) separated by space. <br>
  * These are:
  * 
  * <table cellspacing="8">
@@ -44,7 +44,7 @@ import org.joda.time.MutableDateTime;
  * <th align="left">Special Characters</th>
  * </tr>
  * <tr>
- * <td align="left"><code>Seconds</code></td>
+ * <td align="left"><code>Seconds (may be omitted)</code></td>
  * <td align="left">&nbsp;</th>
  * <td align="left"><code>0-59</code></td>
  * <td align="left">&nbsp;</th>
@@ -143,7 +143,6 @@ public class CronExpression {
             this.to = to;
             this.names = names;
         }
-
     }
 
     private final String expr;
@@ -154,23 +153,39 @@ public class CronExpression {
     private final SimpleField monthField;
     private final DayOfMonthField dayOfMonthField;
 
-    public CronExpression(String expr) {
+    public CronExpression(final String expr) {
+        this(expr, true);
+    }
+
+    public CronExpression(final String expr, final boolean withSeconds) {
         if (expr == null) {
-            throw new IllegalArgumentException("expr is null");
-        }
-        this.expr = expr;
-        String[] parts = expr.split("\\s+");
-        if (parts.length != 6) {
-            throw new IllegalArgumentException(String.format("Invalid cronexpression [%s], expected %s felt, got %s"
-                    , expr, CronFieldType.values().length, parts.length));
+            throw new IllegalArgumentException("expr is null"); //$NON-NLS-1$
         }
 
-        this.secondField = new SimpleField(CronFieldType.SECOND, parts[0]);
-        this.minuteField = new SimpleField(CronFieldType.MINUTE, parts[1]);
-        this.hourField = new SimpleField(CronFieldType.HOUR, parts[2]);
-        this.dayOfMonthField = new DayOfMonthField(parts[3]);
-        this.monthField = new SimpleField(CronFieldType.MONTH, parts[4]);
-        this.dayOfWeekField = new DayOfWeekField(parts[5]);
+        this.expr = expr;
+
+        final int expectedParts = withSeconds ? 6 : 5;
+        final String[] parts = expr.split("\\s+"); //$NON-NLS-1$
+        if (parts.length != expectedParts) {
+            throw new IllegalArgumentException(String.format("Invalid cron expression [%s], expected %s felt, got %s"
+                    , expr, expectedParts, parts.length));
+        }
+
+        int ix = withSeconds ? 1 : 0;
+        this.secondField = new SimpleField(CronFieldType.SECOND, withSeconds ? parts[0] : "*");
+        this.minuteField = new SimpleField(CronFieldType.MINUTE, parts[ix++]);
+        this.hourField = new SimpleField(CronFieldType.HOUR, parts[ix++]);
+        this.dayOfMonthField = new DayOfMonthField(parts[ix++]);
+        this.monthField = new SimpleField(CronFieldType.MONTH, parts[ix++]);
+        this.dayOfWeekField = new DayOfWeekField(parts[ix++]);
+    }
+
+    public static CronExpression create(final String expr) {
+        return new CronExpression(expr, true);
+    }
+
+    public static CronExpression createWithoutSeconds(final String expr) {
+        return new CronExpression(expr, false);
     }
 
     public DateTime nextTimeAfter(DateTime afterTime) {
@@ -465,6 +480,5 @@ public class CronExpression {
         protected boolean matches(int val, FieldPart part) {
             return "?".equals(part.modifier) || super.matches(val, part);
         }
-
     }
 }

--- a/src/main/java/fc/cron/CronExpression.java
+++ b/src/main/java/fc/cron/CronExpression.java
@@ -172,7 +172,7 @@ public class CronExpression {
         }
 
         int ix = withSeconds ? 1 : 0;
-        this.secondField = new SimpleField(CronFieldType.SECOND, withSeconds ? parts[0] : "*");
+        this.secondField = new SimpleField(CronFieldType.SECOND, withSeconds ? parts[0] : "0");
         this.minuteField = new SimpleField(CronFieldType.MINUTE, parts[ix++]);
         this.hourField = new SimpleField(CronFieldType.HOUR, parts[ix++]);
         this.dayOfMonthField = new DayOfMonthField(parts[ix++]);

--- a/src/test/java/fc/cron/CronExpressionTest.java
+++ b/src/test/java/fc/cron/CronExpressionTest.java
@@ -442,4 +442,28 @@ public class CronExpressionTest {
     public void shall_not_not_support_rolling_period() throws Exception {
         new CronExpression("* * 5-1 * * *");
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void non_existing_date_throws_exception() throws Exception {
+        // Will check for the next 4 years - no 30th of February is found so a IAE is thrown.
+        new CronExpression("* * * 30 2 *").nextTimeAfter(DateTime.now());
+    }
+
+    @Test
+    public void test_default_barrier() throws Exception {
+        // the default barrier is 4 years - so leap years are considered.
+        assertThat(new CronExpression("* * * 29 2 *").nextTimeAfter(new DateTime(2012, 3, 1, 00, 00))).isEqualTo(new DateTime(2016, 2, 29, 00, 00));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_one_year_barrier() throws Exception {
+        // The next leap year is 2016, so an IllegalArgumentException is expected.
+        new CronExpression("* * * 29 2 *").nextTimeAfter(new DateTime(2012, 3, 1, 00, 00), new DateTime(2013, 3, 1, 00, 00));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_two_year_barrier() throws Exception {
+        // The next leap year is 2016, so an IllegalArgumentException is expected.
+        new CronExpression("* * * 29 2 *").nextTimeAfter(new DateTime(2012, 3, 1, 00, 00), 1000 * 60 * 60 * 24 * 356 * 2);
+    }
 }

--- a/src/test/java/fc/cron/CronExpressionTest.java
+++ b/src/test/java/fc/cron/CronExpressionTest.java
@@ -466,4 +466,14 @@ public class CronExpressionTest {
         // The next leap year is 2016, so an IllegalArgumentException is expected.
         new CronExpression("* * * 29 2 *").nextTimeAfter(new DateTime(2012, 3, 1, 00, 00), 1000 * 60 * 60 * 24 * 356 * 2);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_seconds_specified_but_should_be_omitted() throws Exception {
+        CronExpression.createWithoutSeconds("* * * 29 2 *");
+    }
+
+    @Test
+    public void test_without_seconds() throws Exception {
+        assertThat(CronExpression.createWithoutSeconds("* * 29 2 *").nextTimeAfter(new DateTime(2012, 3, 1, 00, 00))).isEqualTo(new DateTime(2016, 2, 29, 00, 00));
+    }
 }


### PR DESCRIPTION
I've made two enhancements to your CronExpression.
- At first, searchig for the next february 30th resulted in an endless loop. I've added an "date/time barrier". If the search passes this barrier, an InvalidArgumentException is thrown.
- Furthermore I've added a feature that enables the invoker to omit the seconds in the cron expression.
